### PR TITLE
Apply static branching to download NWIS data

### DIFF
--- a/1_fetch/src/get_site_data.R
+++ b/1_fetch/src/get_site_data.R
@@ -7,7 +7,7 @@ get_site_data <- function(sites_info, state, parameter) {
   # simulate an unreliable web service or internet connection by causing random failures
   set.seed(Sys.time()) # Make sure that the seed changes with every run (targets likes to store the seed)
   if(runif(1) < 0.5) {
-    Sys.sleep(2)
+    Sys.sleep(0.5)
     stop('Ugh, the internet data transfer failed! Try again.')
   }
 

--- a/_targets.R
+++ b/_targets.R
@@ -1,5 +1,7 @@
 
 library(targets)
+library(tarchetypes)
+library(tibble)
 
 options(tidyverse.quiet = TRUE)
 tar_option_set(packages = c("tidyverse", "dataRetrieval", "urbnmapr", "rnaturalearth", "cowplot"))
@@ -10,7 +12,7 @@ source("1_fetch/src/get_site_data.R")
 source("3_visualize/src/map_sites.R")
 
 # Configuration
-states <- c('WI','MN','MI')
+states <- c('WI','MN','MI','IL')
 parameter <- c('00060')
 
 # Targets
@@ -19,12 +21,12 @@ list(
   tar_target(oldest_active_sites, find_oldest_sites(states, parameter)),
 
   # Pull data for oldest sites
-  tar_target(wi_data,
-             get_site_data(oldest_active_sites,states[1],parameter)),
-  tar_target(mn_data,
-             get_site_data(oldest_active_sites,states[2],parameter)),
-  tar_target(mi_data,
-             get_site_data(oldest_active_sites,states[3],parameter)),
+  tar_map(
+    values = tibble(state_abb = states),
+    tar_target(nwis_data,get_site_data(oldest_active_sites,state_abb,parameter))
+    # Insert step for tallying data here
+    # Insert step for plotting data here
+  ),
 
   # Map oldest sites
   tar_target(


### PR DESCRIPTION
This PR addresses issue #4. I've refactored the data targets using static branching so that we now implement the data download **step** using `get_site_data()` for every **task** (state) specified by the user. The code now finds the oldest site, downloads the data, and plots a map showing the oldest gage site in WI, MI, MN, and IL. 