### PR TITLE
add splitter for pulling data from oldest sites

### DIFF
--- a/1_fetch/src/get_site_data.R
+++ b/1_fetch/src/get_site_data.R
@@ -1,7 +1,6 @@
 # download data for each site
 # packages needed: tidyverse, dataRetrieval
-get_site_data <- function(sites_info, state, parameter) {
-  site_info <- filter(sites_info, state_cd == state)
+get_site_data <- function(site_info, state, parameter) {
   message(sprintf('  Retrieving data for %s-%s', state, state))
 
   # simulate an unreliable web service or internet connection by causing random failures

--- a/_targets.R
+++ b/_targets.R
@@ -12,7 +12,7 @@ source("1_fetch/src/get_site_data.R")
 source("3_visualize/src/map_sites.R")
 
 # Configuration
-states <- c('WI','MN','MI','IL')
+states <- c('WI','MN','MI','IL','IN','IA')
 parameter <- c('00060')
 
 # Targets
@@ -23,7 +23,8 @@ list(
   # Pull data for oldest sites
   tar_map(
     values = tibble(state_abb = states),
-    tar_target(nwis_data,get_site_data(oldest_active_sites,state_abb,parameter))
+    tar_target(nwis_inventory,filter(oldest_active_sites, state_cd == state_abb)),
+    tar_target(nwis_data,get_site_data(nwis_inventory,state_abb,parameter))
     # Insert step for tallying data here
     # Insert step for plotting data here
   ),


### PR DESCRIPTION
This PR addresses issue #6. I've added a new target, `nwis_inventory`, which functions as a splitter to use for pulling data from the target `oldest_sites`. With the addition of this new splitter, I made a minor change to the `get_site_data()` function to omit a now redundant filtering step. 

I added IN and IA as new tasks (`states`). When I ran `tar_make()` following these changes, the target `oldest_active_sites` was rebuilt as well as `site_map_png` and the 6 `nwis_inventory` targets associated with each state. The `nwis_data` targets for WI, MN, and IL did not get rebuilt since those data did not need to be downloaded again. Therefore, the only `nwis_data` targets that got built after adding the two new states were `nwis_data_IN` and `nwis_data_IL`, which is good because it saves us download time! 


