### PR TITLE
Combiners

### DIFF
--- a/2_process/src/summarize_targets.R
+++ b/2_process/src/summarize_targets.R
@@ -1,0 +1,9 @@
+# Summarize pipeline metadata
+summarize_targets <- function(ind_file, ...) {
+  ind_tbl <- tar_meta(c(...)) %>%
+    select(tar_name = name, filepath = path, hash = data) %>%
+    mutate(filepath = unlist(filepath))
+
+  readr::write_csv(ind_tbl, ind_file)
+  return(ind_file)
+}

--- a/2_process/src/tally_site_obs.R
+++ b/2_process/src/tally_site_obs.R
@@ -9,3 +9,8 @@ tally_site_obs <- function(site_data) {
     group_by(Site, State, Year) %>%
     summarize(NumObs = length(which(!is.na(Value))), .groups = "keep")
 }
+
+combine_obs_tallies <- function(...){
+  tibble_out <- rbind(...)
+  return(tibble_out)
+}

--- a/3_visualize/log/summary_state_timeseries.csv
+++ b/3_visualize/log/summary_state_timeseries.csv
@@ -1,0 +1,7 @@
+tar_name,filepath,hash
+timeseries_png_WI,3_visualize/out/timeseries_WI.png,bad834eb5b36ebe8
+timeseries_png_MN,3_visualize/out/timeseries_MN.png,83ae26d540c10764
+timeseries_png_MI,3_visualize/out/timeseries_MI.png,d2553fec808f3ed1
+timeseries_png_IL,3_visualize/out/timeseries_IL.png,baac778e858a4b33
+timeseries_png_IN,3_visualize/out/timeseries_IN.png,842821c94803a7af
+timeseries_png_IA,3_visualize/out/timeseries_IA.png,fe259a06ccd8bebd

--- a/_targets.R
+++ b/_targets.R
@@ -5,18 +5,36 @@ library(tibble)
 suppressPackageStartupMessages(library(dplyr))
 
 options(tidyverse.quiet = TRUE)
-tar_option_set(packages = c("tidyverse", "dataRetrieval", "urbnmapr", "rnaturalearth", "cowplot","lubridate"))
+tar_option_set(packages = c("tidyverse", "dataRetrieval", "urbnmapr", "rnaturalearth",
+                            "cowplot","lubridate","leaflet","leafpop","htmlwidgets"))
 
 # Load functions needed by targets below
 source("1_fetch/src/find_oldest_sites.R")
 source("1_fetch/src/get_site_data.R")
 source("2_process/src/tally_site_obs.R")
+source("2_process/src/summarize_targets.R")
 source("3_visualize/src/map_sites.R")
 source("3_visualize/src/plot_site_data.R")
+source("3_visualize/src/plot_data_coverage.R")
+source("3_visualize/src/map_timeseries.R")
 
 # Configuration
 states <- c('WI','MN','MI','IL','IN','IA')
 parameter <- c('00060')
+
+mapped_by_state_targets <- tar_map(
+  values = tibble(state_abb = states) %>%
+    mutate(state_plot_files = sprintf("3_visualize/out/timeseries_%s.png",state_abb)),
+  tar_target(nwis_inventory,filter(oldest_active_sites, state_cd == state_abb)),
+  tar_target(nwis_data,get_site_data(nwis_inventory,state_abb,parameter)),
+  # tally data
+  tar_target(tally,tally_site_obs(nwis_data)),
+  # plot data
+  tar_target(timeseries_png,plot_site_data(state_plot_files,nwis_data,parameter),
+             format = "file"),
+  names = state_abb,
+  unlist = FALSE
+)
 
 # Targets
 list(
@@ -24,22 +42,35 @@ list(
   tar_target(oldest_active_sites, find_oldest_sites(states, parameter)),
 
   # Pull data for oldest sites
-  tar_map(
-    values = tibble(state_abb = states) %>%
-      mutate(state_plot_files = sprintf("3_visualize/out/timeseries_%s.png",state_abb)),
-    tar_target(nwis_inventory,filter(oldest_active_sites, state_cd == state_abb)),
-    tar_target(nwis_data,get_site_data(nwis_inventory,state_abb,parameter)),
-    # Insert step for tallying data here
-    tar_target(tally,tally_site_obs(nwis_data)),
-    # Insert step for plotting data here
-    tar_target(timeseries_png,plot_site_data(state_plot_files,nwis_data,parameter)),
-    names = state_abb
+  mapped_by_state_targets,
+  tar_combine(obs_tallies,
+              mapped_by_state_targets$tally,
+              command = combine_obs_tallies(!!!.x)),
+
+  # Create and save indicator file
+  tar_combine(summary_state_timeseries_csv,
+              mapped_by_state_targets$timeseries_png,
+              command = summarize_targets("3_visualize/log/summary_state_timeseries.csv",!!!.x),
+              format = "file"),
+
+  # Plot data coverage for oldest sites
+  tar_target(
+    data_coverage_png,
+    plot_data_coverage(obs_tallies,"3_visualize/out/data_coverage.png",parameter="00060"),
+    format = "file"
   ),
 
   # Map oldest sites
   tar_target(
     site_map_png,
     map_sites("3_visualize/out/site_map.png", oldest_active_sites),
+    format = "file"
+  ),
+
+  # Create interactive map
+  tar_target(
+    timeseries_map_html,
+    map_timeseries(oldest_active_sites,summary_state_timeseries_csv,"3_visualize/out/timeseries_map.html"),
     format = "file"
   )
 )


### PR DESCRIPTION
This PR addresses issue #10. The code changes here add the following features to the project pipeline:

- Use a combiner with static branching to combine the tallied observations for each of the oldest active sites we identified for the six states of interest into one tibble 
- Use a combiner to generate an **indicator file** so that we can track any changes to the `timeseries_png` plots
- Generate an interactive leaflet map that shows the site locations, names, number of observations, and timeseries plots for each of the oldest active sites. A screenshot is copied below:

![leaflet_map](https://user-images.githubusercontent.com/8785034/141810714-b9490a73-7263-4bdd-8562-120db42f7940.PNG)


